### PR TITLE
Absolute paths & output directory creation

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ module.exports = function(input, options, cb) {
   }, options);
 
   // Read input file
-  var inputFile = fs.readFileSync(path.join(process.cwd(), input));
+  var inputFile = path.isAbsolute(input) ? fs.readFileSync(path.join(input)) : fs.readFileSync(path.join(process.cwd(), input));
   // The divider for pages is four newlines
   var pages = inputFile.toString().replace(/(?:\r\n)/mg, "\n").split('\n\n\n\n');
 
@@ -55,9 +55,9 @@ module.exports = function(input, options, cb) {
   });
 
   // Write file to disk
-  var templateFile = fs.readFileSync(path.join(process.cwd(), options.template));
+  var templateFile = path.isAbsolute(options.template) ? fs.readFileSync(path.join(options.template)) : fs.readFileSync(path.join(process.cwd(), options.template));
   var template = handlebars.compile(templateFile.toString(), { noEscape: true });
-  var outputPath = path.join(process.cwd(), options.output);
+  var outputPath = path.isAbsolute(options.template) ? path.join(options.output) : path.join(process.cwd(), options.output);
 
   fs.writeFile(outputPath, template({ pages: pages }), cb);
 }

--- a/index.js
+++ b/index.js
@@ -58,6 +58,11 @@ module.exports = function(input, options, cb) {
   var templateFile = path.isAbsolute(options.template) ? fs.readFileSync(path.join(options.template)) : fs.readFileSync(path.join(process.cwd(), options.template));
   var template = handlebars.compile(templateFile.toString(), { noEscape: true });
   var outputPath = path.isAbsolute(options.template) ? path.join(options.output) : path.join(process.cwd(), options.output);
+  var outputDir = path.dirname(outputPath);
+
+  if(!fs.existsSync(outputDir)) {
+    fs.mkdirSync(outputDir);
+  }
 
   fs.writeFile(outputPath, template({ pages: pages }), cb);
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "style-sherpa",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "A simple style guide generator.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Hi,

I've some issues in my current gulp setup where I'm using style-sherpa.
Precisely 2 issues:

1. Absolute paths doesn't work since they are getting joined with the cwd path
2. If the output folder doesn't exist, the stream fails instead of creating that folder

I've fixed both issues in this PR.

@kball would be great if you review and accept this if it's fine

Best regards
Kai
